### PR TITLE
Add support for self-signed SSL communication with parsoid.

### DIFF
--- a/mediawiki/docker-entrypoint.sh
+++ b/mediawiki/docker-entrypoint.sh
@@ -58,6 +58,9 @@ php /var/www/html/maintenance/install.php \
 	"$MEDIAWIKI_SITE_NAME" \
 	"$MEDIAWIKI_ADMIN_USER"
 
+# Regenerate ca-certs
+update-ca-certificates -f &>/dev/null
+
 # Dirty but... good enough :D
 sed '/?>/d' /var/www/html/LocalSettings.php && { cat /data/custom_settings.php; echo; echo "?>"; } >> /var/www/html/LocalSettings.php
 


### PR DESCRIPTION
While docker run we can optionally mount a self signed CA using `-v`. `update-ca-certificates` will make it trusted. This allows to wrap parsoid<->mediawiki communication with self-signed SSL.