### PR TITLE
Switch parsoid to alpine and upgrade to v0.10.0

### DIFF
--- a/parsoid/Dockerfile
+++ b/parsoid/Dockerfile
@@ -1,24 +1,24 @@
-FROM debian:jessie
+FROM alpine:latest
 
-RUN set -x; \
-    apt-get update -qq \
-    && apt-get install -y apt-transport-https curl \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -sL https://deb.nodesource.com/setup_12.x | bash -
+# Versions from https://github.com/wikimedia/parsoid/releases
+ENV PARSOID_VERSION=v0.10.0
+ENV PARSOID_PATH=/usr/src/app/
 
-RUN apt-key advanced --keyserver keys.gnupg.net --recv-keys 90E9F83F22250DD7 \
-    && echo "deb https://releases.wikimedia.org/debian jessie-mediawiki main" > /etc/apt/sources.list.d/parsoid.list
-
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends nodejs parsoid \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /etc/mediawiki/parsoid
+RUN apk add --no-cache nodejs nodejs-npm python git make \
+    && mkdir -p ${PARSOID_PATH} \
+    && git clone \
+        --branch ${PARSOID_VERSION} \
+        --single-branch \
+        --depth 1 \
+        --quiet \
+        https://github.com/wikimedia/parsoid \
+        $PARSOID_PATH \
+    && cd $PARSOID_PATH \
+    && npm install
 
 EXPOSE 8000
 
 COPY docker-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/usr/bin/nodejs", "/usr/lib/parsoid/src/bin/server.js", "-c", "/etc/mediawiki/parsoid/config.yaml", "-n", "0"]
+CMD ["/usr/bin/node", "/usr/src/app/bin/server.js", "-c", "/usr/src/app/config.yaml", "-n", "0"]

--- a/parsoid/docker-entrypoint.sh
+++ b/parsoid/docker-entrypoint.sh
@@ -1,3 +1,18 @@
 #!/bin/bash
-sed -i -e "s#/w/api.php#${MEDIAWIKI_API_ENDPOINT}#" -e "s#http://localhost#${MEDIAWIKI_URL}#g" /etc/mediawiki/parsoid/config.yaml
+
+# See https://github.com/wikimedia/parsoid/blob/master/config.example.yaml
+cat <<EOF > ${PARSOID_PATH}/config.yaml
+worker_heartbeat_timeout: 300000
+
+logging:
+    level: info
+
+services:
+  - module: lib/index.js
+    entrypoint: apiServiceWorker
+    conf:
+      mwApis:
+      - uri: '${MEDIAWIKI_URL}${MEDIAWIKI_API_ENDPOINT}'
+EOF
+
 exec $@


### PR DESCRIPTION
Switching docker to alpine and upgrading parsoid to v0.10.0. Now we will install parsoid directly from mediawiki's github.com mirror so it is gonna be easier to control installed version. 