### PR TITLE
Downgrade parsoid to 0.9.0

### DIFF
--- a/parsoid/Dockerfile
+++ b/parsoid/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
 # Versions from https://github.com/wikimedia/parsoid/releases
-ENV PARSOID_VERSION=v0.10.0
+ENV PARSOID_VERSION=v0.9.0
 ENV PARSOID_PATH=/usr/src/app/
 
 RUN apk add --no-cache nodejs nodejs-npm python git make \


### PR DESCRIPTION
0.10.0 turned out to be too new for mediawiki 1.32 and some parts of wiki texts were marked as unable to be edited in visualeditor and source editor has to be used.

